### PR TITLE
Avoid "Capistrano tasks may only be invoked once." warning

### DIFF
--- a/lib/capistrano/tasks/deploy-lock.rake
+++ b/lib/capistrano/tasks/deploy-lock.rake
@@ -122,18 +122,10 @@ namespace :deploy do
     end
   end
   
-  before 'deploy:started', 'check_lock' do
-    invoke 'deploy:check_lock'
-  end
-  before 'deploy:started', 'create_lock' do
-    invoke 'deploy:create_lock'
-  end
-  after 'deploy:published', 'unlock' do
-    invoke 'deploy:unlock:default'
-  end
-  after 'deploy:rollback', 'unlock' do
-    invoke 'deploy:unlock:default'
-  end
+  before 'deploy:started',   'check_lock'
+  before 'deploy:started',   'create_lock'
+  after  'deploy:published', 'unlock:default'
+  after  'deploy:rollback',  'unlock:default'
 
 end
 


### PR DESCRIPTION
Avoid this warning when deploying:

Capistrano tasks may only be invoked once. Since task `deploy:check_lock' was previously invoked, invoke("deploy:check_lock") at /Users/allaire/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/capistrano-deploy-lock-1.0.3/lib/capistrano/tasks/deploy-lock.rake:126 will be skipped.
If you really meant to run this task again, first call Rake::Task["deploy:check_lock"].reenable
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686