### PR TITLE
Add ability to lock multiple deploys for the same environment on local as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ set :deploy_lock_roles, -> { :app }
 # Deploy lock expiry (in second)
 # Default 15 minutes
 set :default_lock_expiry, (15 * 60)
+
+# Lock multiple deploys from local machine as well
+set :enable_deploy_lock_local, true
+
+# Create the lock file in the current working directory
+set :local_lock_path, '.' # working directory
+
+# This is where the lock file will be created locally
+set :deploy_lock_file_local, -> { File.join(fetch(:local_lock_path), 'deploy-lock.yml') }
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ set :enable_deploy_lock_local, true
 set :local_lock_path, '.' # working directory
 
 # This is where the lock file will be created locally
-set :deploy_lock_file_local, -> { File.join(fetch(:local_lock_path), 'deploy-lock.yml') }
+set :deploy_lock_file_local, -> { File.join(fetch(:local_lock_path), "#{fetch(:rails_env)}-#{fetch(:stage)}-deploy-lock.yml") }
 ```
 
 ## Contributing

--- a/lib/capistrano/tasks/deploy-lock.rake
+++ b/lib/capistrano/tasks/deploy-lock.rake
@@ -162,6 +162,7 @@ def write_deploy_lock(deploy_lock)
   end
 
   if fetch(:enable_deploy_lock_local)
+    Dir.mkdir(shared_path)
     File.write(fetch(:deploy_lock_file_local), deploy_lock.to_yaml)
   end
 end

--- a/lib/capistrano/tasks/deploy-lock.rake
+++ b/lib/capistrano/tasks/deploy-lock.rake
@@ -162,7 +162,6 @@ def write_deploy_lock(deploy_lock)
   end
 
   if fetch(:enable_deploy_lock_local)
-    Dir.mkdir(shared_path)
     File.write(fetch(:deploy_lock_file_local), deploy_lock.to_yaml)
   end
 end


### PR DESCRIPTION
This will help avoid any race conditions in case multiple deploys are triggered from the same host (local or bastion host).